### PR TITLE
feat: add `qemu-guest-agent` and `spice-webdavd`

### DIFF
--- a/recipe.yml
+++ b/recipe.yml
@@ -29,6 +29,12 @@ modules:
     - virtualbox-guest-utils
     - virtualbox-guest-x11
 
+- name: qemu
+  type: apt
+  source:
+    packages:
+    - qemu-guest-agent
+
 - name: cleanup
   type: shell
   commands:

--- a/recipe.yml
+++ b/recipe.yml
@@ -34,6 +34,7 @@ modules:
   source:
     packages:
     - qemu-guest-agent
+    - spice-webdavd
 
 - name: cleanup
   type: shell


### PR DESCRIPTION
This PR adds `qemu-guest-agent` which allows advanced host and guest integration for QEMU-based virtualizers like `virt-manager` and Proxmox.

**Edit**: Added `spice-webdavd` too, it seems to be present in the live session but not after it (this is required for file sharing between VM and host).