### PR TITLE
chore: bump Vib action to v0.6.2

### DIFF
--- a/.github/workflows/vib-build.yml
+++ b/.github/workflows/vib-build.yml
@@ -18,10 +18,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - uses: vanilla-os/vib-gh-action@v0.3.3-1
+    - uses: vanilla-os/vib-gh-action@v0.6.2
       with:
         recipe: 'recipe.yml'
-        plugins: 'Vanilla-OS/vib-fsguard:v1.2-1'
+        plugins: 'Vanilla-OS/vib-fsguard:v1.3-2'
 
     - name: Build the Docker image
       run: docker image build -f Containerfile --tag ghcr.io/vanilla-os/vm:main .

--- a/.github/workflows/vib-pr.yml
+++ b/.github/workflows/vib-pr.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - uses: vanilla-os/vib-gh-action@v0.3.3-1
+    - uses: vanilla-os/vib-gh-action@v0.6.2
       with:
         recipe: 'recipe.yml'
-        plugins: 'Vanilla-OS/vib-fsguard:v1.2-1'
+        plugins: 'Vanilla-OS/vib-fsguard:v1.3-2'
 
     - name: Build the Docker image
       run: docker image build -f Containerfile --tag vanillaos/vm:validation .

--- a/recipe.yml
+++ b/recipe.yml
@@ -1,58 +1,61 @@
-base: ghcr.io/vanilla-os/desktop:main
 name: Vanilla Desktop VM
 id: vanilla-vm
-labels:
-  maintainer: Vanilla OS Contributors
-args:
-  DEBIAN_FRONTEND: noninteractive
-runs:
-- echo 'APT::Install-Recommends "1";' > /etc/apt/apt.conf.d/01norecommends
+stages:
+- id: build
+  base: ghcr.io/vanilla-os/desktop:main
+  singlelayer: false
+  labels:
+    maintainer: Vanilla OS Contributors
+  args:
+    DEBIAN_FRONTEND: noninteractive
+  runs:
+  - echo 'APT::Install-Recommends "1";' > /etc/apt/apt.conf.d/01norecommends
 
-modules:
-- name: init-setup
-  type: shell
-  commands:
-  - lpkg --unlock
-  - apt update
-
-- name: vm-tools
-  type: apt
-  source:
-    packages:
-    - open-vm-tools 
-    - open-vm-tools-desktop
-
-- name: virtualbox-guest-additions
-  type: apt
-  source:
-    packages:
-    - virtualbox-guest-utils
-    - virtualbox-guest-x11
-
-- name: qemu
-  type: apt
-  source:
-    packages:
-    - qemu-guest-agent
-    - spice-webdavd
-
-- name: cleanup
-  type: shell
-  commands:
-  - apt autoremove -y
-  - apt clean
-  - lpkg --lock
-
-- name: fsguard
-  type: fsguard
-  FsGuardLocation: "/usr/sbin/FsGuard"
-  CustomFsGuard: false
-  GenerateKey: true
-  FilelistPaths: ["/usr/bin"]
   modules:
-    - name: remove-prev-fsguard
-      type: shell
-      commands:
-        - rm -rf /FsGuard 
-        - rm -f ./minisign.pub ./minisign.key 
-        - chmod +x /usr/sbin/init
+  - name: init-setup
+    type: shell
+    commands:
+    - lpkg --unlock
+    - apt update
+
+  - name: vm-tools
+    type: apt
+    source:
+      packages:
+      - open-vm-tools 
+      - open-vm-tools-desktop
+
+  - name: virtualbox-guest-additions
+    type: apt
+    source:
+      packages:
+      - virtualbox-guest-utils
+      - virtualbox-guest-x11
+
+  - name: qemu
+    type: apt
+    source:
+      packages:
+      - qemu-guest-agent
+      - spice-webdavd
+
+  - name: cleanup
+    type: shell
+    commands:
+    - apt autoremove -y
+    - apt clean
+    - lpkg --lock
+
+  - name: fsguard
+    type: fsguard
+    FsGuardLocation: "/usr/sbin/FsGuard"
+    CustomFsGuard: false
+    GenerateKey: true
+    FilelistPaths: ["/usr/bin"]
+    modules:
+      - name: remove-prev-fsguard
+        type: shell
+        commands:
+          - rm -rf /FsGuard 
+          - rm -f ./minisign.pub ./minisign.key 
+          - chmod +x /usr/sbin/init


### PR DESCRIPTION
## Changes

- Bump Vib action to `v0.6.2`.
- Update `recipe.yml` to new syntax.