### PR TITLE
feat: add spice-vdagent

### DIFF
--- a/recipe.yml
+++ b/recipe.yml
@@ -37,6 +37,12 @@ stages:
     source:
       packages:
       - qemu-guest-agent
+
+  - name: spice
+    type: apt
+    source:
+      packages:
+      - spice-vdagent
       - spice-webdavd
 
   - name: cleanup


### PR DESCRIPTION
This PR adds the `spice-vdagent` package to the recipe and separates the spice packages into a separate module instead of being present under the QEMU module.

It is particularly useful for  GNOME Boxes (display resizing [clipboard support is already present], etc) and Proxmox SPICE graphic card display mode (for clipboard sharing, etc).

## Details

`spice-vdagent` is a Spice guest agent X11 session agent which supports:

 - Client mouse mode (no need to grab mouse by client, no mouse lag).

 -  Automatic adjustment of the  X11  session's number of virtual monitors,  and their resolution, to the number of client windows and their resolution.

 - Support of copy and paste (text and images) between the active X11 session and the client, this supports both the primary selection and the clipboard.

- Support for transferring files from the client to the agent.

## Testing

I have tested the changes by manually installing the package using `abroot pkg` under a VM running the `vm-image`.